### PR TITLE
Updating Reference Grammar's version number on index.js from 1.2.7 to…

### DIFF
--- a/en/index.js
+++ b/en/index.js
@@ -648,7 +648,7 @@ function RenderDesktop() {
   outp.style.display = 'none';
   descr.style.display = 'block';
   var obj = {
-    '@CLL': ['.inglic.', 'Reference Grammar', '../pixra/cll.png', 1, 'https://lojban.pw/cll/uncll-1.2.7/xhtml_section_chunks/'],
+    '@CLL': ['.inglic.', 'Reference Grammar', '../pixra/cll.png', 1, 'https://lojban.pw/cll/uncll-1.2.9/xhtml_section_chunks/'],
     '@lojban.pw': ['.inglic.', 'Lojban-Chan', '../pixra/jbotcan.svg', 1, 'https://lojban.pw'],
     muplis: [0, 'la muplis', '../pixra/taplamuplis.svg', 2.1],
     jb: [0, 'English - Lojban examples', '../pixra/snime-1.svg', 1],

--- a/eo/index.js
+++ b/eo/index.js
@@ -648,7 +648,7 @@ function RenderDesktop() {
   outp.style.display = 'none';
   descr.style.display = 'block';
   var obj = {
-    '@CLL': ['.inglic.', 'Reference Grammar', '../pixra/cll.png', 1, 'https://lojban.pw/cll/uncll-1.2.7/xhtml_section_chunks/'],
+    '@CLL': ['.inglic.', 'Reference Grammar', '../pixra/cll.png', 1, 'https://lojban.pw/cll/uncll-1.2.9/xhtml_section_chunks/'],
     '@lojban.pw': ['.inglic.', 'Lojban-Chan', '../pixra/jbotcan.svg', 1, 'https://lojban.pw'],
     muplis: [0, 'la muplis', '../pixra/taplamuplis.svg', 2.1],
     jb: [0, 'English - Lojban examples', '../pixra/snime-1.svg', 1],

--- a/es/index.js
+++ b/es/index.js
@@ -648,7 +648,7 @@ function RenderDesktop() {
   outp.style.display = 'none';
   descr.style.display = 'block';
   var obj = {
-    '@CLL': ['.inglic.', 'Reference Grammar', '../pixra/cll.png', 1, 'https://lojban.pw/cll/uncll-1.2.7/xhtml_section_chunks/'],
+    '@CLL': ['.inglic.', 'Reference Grammar', '../pixra/cll.png', 1, 'https://lojban.pw/cll/uncll-1.2.9/xhtml_section_chunks/'],
     '@lojban.pw': ['.inglic.', 'Lojban-Chan', '../pixra/jbotcan.svg', 1, 'https://lojban.pw'],
     muplis: [0, 'la muplis', '../pixra/taplamuplis.svg', 2.1],
     jb: [0, 'English - Lojban examples', '../pixra/snime-1.svg', 1],

--- a/fr-facile/index.js
+++ b/fr-facile/index.js
@@ -648,7 +648,7 @@ function RenderDesktop() {
   outp.style.display = 'none';
   descr.style.display = 'block';
   var obj = {
-    '@CLL': ['.inglic.', 'Reference Grammar', '../pixra/cll.png', 1, 'https://lojban.pw/cll/uncll-1.2.7/xhtml_section_chunks/'],
+    '@CLL': ['.inglic.', 'Reference Grammar', '../pixra/cll.png', 1, 'https://lojban.pw/cll/uncll-1.2.9/xhtml_section_chunks/'],
     '@lojban.pw': ['.inglic.', 'Lojban-Chan', '../pixra/jbotcan.svg', 1, 'https://lojban.pw'],
     muplis: [0, 'la muplis', '../pixra/taplamuplis.svg', 2.1],
     jb: [0, 'English - Lojban examples', '../pixra/snime-1.svg', 1],

--- a/ja/index.js
+++ b/ja/index.js
@@ -648,7 +648,7 @@ function RenderDesktop() {
   outp.style.display = 'none';
   descr.style.display = 'block';
   var obj = {
-    '@CLL': ['.inglic.', 'Reference Grammar', '../pixra/cll.png', 1, 'https://lojban.pw/cll/uncll-1.2.7/xhtml_section_chunks/'],
+    '@CLL': ['.inglic.', 'Reference Grammar', '../pixra/cll.png', 1, 'https://lojban.pw/cll/uncll-1.2.9/xhtml_section_chunks/'],
     '@lojban.pw': ['.inglic.', 'Lojban-Chan', '../pixra/jbotcan.svg', 1, 'https://lojban.pw'],
     muplis: [0, 'la muplis', '../pixra/taplamuplis.svg', 2.1],
     jb: [0, 'English - Lojban examples', '../pixra/snime-1.svg', 1],

--- a/jb/index.js
+++ b/jb/index.js
@@ -648,7 +648,7 @@ function RenderDesktop() {
   outp.style.display = 'none';
   descr.style.display = 'block';
   var obj = {
-    '@CLL': ['.inglic.', 'Reference Grammar', '../pixra/cll.png', 1, 'https://lojban.pw/cll/uncll-1.2.7/xhtml_section_chunks/'],
+    '@CLL': ['.inglic.', 'Reference Grammar', '../pixra/cll.png', 1, 'https://lojban.pw/cll/uncll-1.2.9/xhtml_section_chunks/'],
     '@lojban.pw': ['.inglic.', 'Lojban-Chan', '../pixra/jbotcan.svg', 1, 'https://lojban.pw'],
     muplis: [0, 'la muplis', '../pixra/taplamuplis.svg', 2.1],
     jb: [0, 'English - Lojban examples', '../pixra/snime-1.svg', 1],

--- a/jbo/index.js
+++ b/jbo/index.js
@@ -648,7 +648,7 @@ function RenderDesktop() {
   outp.style.display = 'none';
   descr.style.display = 'block';
   var obj = {
-    '@CLL': ['.inglic.', 'Reference Grammar', '../pixra/cll.png', 1, 'https://lojban.pw/cll/uncll-1.2.7/xhtml_section_chunks/'],
+    '@CLL': ['.inglic.', 'Reference Grammar', '../pixra/cll.png', 1, 'https://lojban.pw/cll/uncll-1.2.9/xhtml_section_chunks/'],
     '@lojban.pw': ['.inglic.', 'Lojban-Chan', '../pixra/jbotcan.svg', 1, 'https://lojban.pw'],
     muplis: [0, 'la muplis', '../pixra/taplamuplis.svg', 2.1],
     jb: [0, 'English - Lojban examples', '../pixra/snime-1.svg', 1],

--- a/muplis/index.js
+++ b/muplis/index.js
@@ -648,7 +648,7 @@ function RenderDesktop() {
   outp.style.display = 'none';
   descr.style.display = 'block';
   var obj = {
-    '@CLL': ['.inglic.', 'Reference Grammar', '../pixra/cll.png', 1, 'https://lojban.pw/cll/uncll-1.2.7/xhtml_section_chunks/'],
+    '@CLL': ['.inglic.', 'Reference Grammar', '../pixra/cll.png', 1, 'https://lojban.pw/cll/uncll-1.2.9/xhtml_section_chunks/'],
     '@lojban.pw': ['.inglic.', 'Lojban-Chan', '../pixra/jbotcan.svg', 1, 'https://lojban.pw'],
     muplis: [0, 'la muplis', '../pixra/taplamuplis.svg', 2.1],
     jb: [0, 'English - Lojban examples', '../pixra/snime-1.svg', 1],

--- a/ru/index.js
+++ b/ru/index.js
@@ -648,7 +648,7 @@ function RenderDesktop() {
   outp.style.display = 'none';
   descr.style.display = 'block';
   var obj = {
-    '@CLL': ['.inglic.', 'Reference Grammar', '../pixra/cll.png', 1, 'https://lojban.pw/cll/uncll-1.2.7/xhtml_section_chunks/'],
+    '@CLL': ['.inglic.', 'Reference Grammar', '../pixra/cll.png', 1, 'https://lojban.pw/cll/uncll-1.2.9/xhtml_section_chunks/'],
     '@lojban.pw': ['.inglic.', 'Lojban-Chan', '../pixra/jbotcan.svg', 1, 'https://lojban.pw'],
     muplis: [0, 'la muplis', '../pixra/taplamuplis.svg', 2.1],
     jb: [0, 'English - Lojban examples', '../pixra/snime-1.svg', 1],

--- a/zh/index.js
+++ b/zh/index.js
@@ -648,7 +648,7 @@ function RenderDesktop() {
   outp.style.display = 'none';
   descr.style.display = 'block';
   var obj = {
-    '@CLL': ['.inglic.', 'Reference Grammar', '../pixra/cll.png', 1, 'https://lojban.pw/cll/uncll-1.2.7/xhtml_section_chunks/'],
+    '@CLL': ['.inglic.', 'Reference Grammar', '../pixra/cll.png', 1, 'https://lojban.pw/cll/uncll-1.2.9/xhtml_section_chunks/'],
     '@lojban.pw': ['.inglic.', 'Lojban-Chan', '../pixra/jbotcan.svg', 1, 'https://lojban.pw'],
     muplis: [0, 'la muplis', '../pixra/taplamuplis.svg', 2.1],
     jb: [0, 'English - Lojban examples', '../pixra/snime-1.svg', 1],


### PR DESCRIPTION
… 1.2.9 (on other versions than jbo)

Didn't edit every index.js there because not all of them were visible on the main webpage.